### PR TITLE
[FEATURE][YM-26498] Environment too dark detection (Android)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 200
+        versionName "2.0.0"
     }
     buildTypes {
         release {
@@ -54,7 +54,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${project.ext.kotlinVersion}"
-    implementation 'com.yoti.mobile.android:face-capture-bundled:2.3.1'
+    implementation 'com.yoti.mobile.android:face-capture-bundled:3.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'

--- a/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureView.java
+++ b/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureView.java
@@ -32,6 +32,7 @@ public class YotiFaceCaptureView extends LinearLayout {
   private ImageQuality mImageQuality;
   private boolean mRequireValidAngle;
   private boolean mRequireEyesOpen;
+  private boolean mRequireBrightEnvironment = true;
   private int mRequiredStableFrames;
   private ReadableArray mScanningArea;
   private final CameraStateListener mCameraStateListener = new CameraStateListener() {
@@ -152,6 +153,10 @@ public class YotiFaceCaptureView extends LinearLayout {
     mRequiredStableFrames = requiredStableFrames;
   }
 
+  public void setRequireBrightEnvironment(Boolean requireBrightEnvironment) {
+    mRequireBrightEnvironment = requireBrightEnvironment;
+  }
+
   public void startCamera() {
     mFaceCapture.startCamera((LifecycleOwner) this.context.getCurrentActivity(), mCameraStateListener);
   }
@@ -173,6 +178,7 @@ public class YotiFaceCaptureView extends LinearLayout {
       mImageQuality,
       mRequireValidAngle,
       mRequireEyesOpen,
+      mRequireBrightEnvironment,
       mRequiredStableFrames
     );
     mFaceCapture.startAnalysing(configuration, mFaceCaptureListener);

--- a/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureViewManager.java
+++ b/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureViewManager.java
@@ -72,4 +72,9 @@ public class YotiFaceCaptureViewManager extends SimpleViewManager<YotiFaceCaptur
   public void setRequiredStableFrames(YotiFaceCaptureView view, int requireStableFrames) {
     view.setRequiredStableFrames(requireStableFrames);
   }
+
+  @ReactProp(name = "requireBrightEnvironment", defaultBoolean = true)
+  public void setRequireBrightEnvironment(YotiFaceCaptureView view, boolean requireBrightEnvironment) {
+    view.setRequireBrightEnvironment(requireBrightEnvironment);
+  }
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -72,6 +72,7 @@ export default function App() {
         requireEyesOpen={false}
         requiredStableFrames={1}
         requireValidAngle={false}
+        requireBrightEnvironment
         scanningArea={[0, 0, nativeWindowWidth, nativeWindowHeight]}
         onFaceCaptureAnalyzedImage={(result) => {
           const { croppedImage } = result;

--- a/src/RNYotiCapture.android.tsx
+++ b/src/RNYotiCapture.android.tsx
@@ -28,6 +28,7 @@ type NATIVE_ANALYSIS_FAILURE_CAUSE =
   | 'NoFaceDetected'
   | 'FaceNotCentered'
   | 'FaceNotStraight'
+  | 'EnvironmentTooDark'
   | 'AnalysisError'
   | 'MultipleFacesDetected';
 
@@ -77,6 +78,7 @@ interface NativeFaceCaptureViewAndroid {
   requireEyesOpen: boolean;
   requireValidAngle: boolean;
   requiredStableFrames: number;
+  requireBrightEnvironment: Boolean;
   imageQuality: IMAGE_QUALITY;
   scanningArea: Array<number>;
   onCameraStateChange: (
@@ -97,6 +99,7 @@ const FACE_CAPTURE_FAILURE_RENAMING: FailureRenaming = {
   NoFaceDetected: 'FaceCaptureAnalysisErrorNoFaceDetected',
   FaceNotCentered: 'FaceCaptureAnalysisErrorFaceNotCentered',
   FaceNotStraight: 'FaceCaptureAnalysisErrorFaceNotStraight',
+  EnvironmentTooDark: 'FaceCaptureAnalysisErrorEnvironmentTooDark',
   AnalysisError: 'FaceCaptureAnalysisErrorFaceAnalysisFailed',
   MultipleFacesDetected: 'FaceCaptureAnalysisErrorMultipleFaces',
 };
@@ -208,6 +211,7 @@ export default class RNYotiCapture extends React.Component<ComponentProps> {
   render() {
     const {
       requireEyesOpen = false,
+      requireBrightEnvironment = true,
       requireValidAngle = false,
       requiredStableFrames = 3,
       imageQuality = IMAGE_QUALITY_MEDIUM,
@@ -225,6 +229,7 @@ export default class RNYotiCapture extends React.Component<ComponentProps> {
         requireEyesOpen={requireEyesOpen}
         requireValidAngle={requireValidAngle}
         requiredStableFrames={requiredStableFrames}
+        requireBrightEnvironment={requireBrightEnvironment}
         imageQuality={imageQuality}
         scanningArea={scanningArea}
         ref={this._setReference}

--- a/src/RNYotiCaptureTypes.tsx
+++ b/src/RNYotiCaptureTypes.tsx
@@ -70,6 +70,7 @@ export type ANALYSIS_FAILURE_CAUSE =
   | 'FaceCaptureAnalysisErrorNoFaceDetected'
   | 'FaceCaptureAnalysisErrorFaceNotCentered'
   | 'FaceCaptureAnalysisErrorFaceNotStraight'
+  | 'FaceCaptureAnalysisErrorEnvironmentTooDark'
   | 'FaceCaptureAnalysisErrorFaceAnalysisFailed'
   | 'FaceCaptureAnalysisErrorMultipleFaces';
 
@@ -92,6 +93,7 @@ export type ComponentProps = {
   requireEyesOpen?: boolean;
   requireValidAngle?: boolean;
   requiredStableFrames?: number;
+  requireBrightEnvironment?: boolean;
   imageQuality?: IMAGE_QUALITY;
   scanningArea?: Array<number>;
   onFaceCaptureAnalyzedImage: (faceCaptureResult: FaceCaptureResult) => void;


### PR DESCRIPTION
## Purpose
Android: New API parameter to activate light detection and require a bright environment for a valid capture. 

Note: iOS client will be updated in a separate ticket. 

## External References (e.g. Jira / Zeplin / Confluence)
[YM-26498](https://lampkicking.atlassian.net/browse/YM-26498)

## Approach
Create `requireBrightEnvironment` new flag for SDK setup. Default value is `true`.

## Scope of changes
SDK Android RN Wrapper classes and App.js SDK setup.

## Checklist
You need to clone this PR and do the following checks:

- [x] Require bright environment is enabled:
1. Follow [README.md](https://github.com/getyoti/react-native-yoti-face-capture/blob/release/2.0.0/example/README.md) instructions and run Android client.
2. Turn off lights and check that `FaceCaptureAnalysisErrorEnvironmentTooDark` validation error appears.

- [x] Require bright environment is disabled:
1. Update example/src/App.js file line 75 to `requireBrightEnvironment={false}`
1. Follow [README.md](https://github.com/getyoti/react-native-yoti-face-capture/blob/release/2.0.0/example/README.md) instructions and run Android client.
2. Turn off lights and check that `FaceCaptureAnalysisErrorEnvironmentTooDark` validation error **doesn't appear**.

#### Tagged
@lampkicking/android-dev
