### PR TITLE
[Bug] YM-27307: Fixing crash after using the framework as a component inside of a navigation

### DIFF
--- a/ios/RNYotiFaceCaptureView.m
+++ b/ios/RNYotiFaceCaptureView.m
@@ -6,7 +6,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
-    self.rootViewController = RCTPresentedViewController();
+    self.rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
     self.faceCaptureViewController = [FaceCapture faceCaptureViewController];
     self.faceCaptureViewController.delegate = self;
     self.faceCaptureViewController.view.backgroundColor = [UIColor clearColor];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getyoti/react-native-yoti-face-capture",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An easy to use face detection component for React Native from Yoti.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Purpose
- Replaced RCTPresentedViewController for the rootViewController of the keyWindow
- Update package version to the next release version

## External References (e.g. Jira / Zeplin / Confluence)
[Jira](https://lampkicking.atlassian.net/browse/YM-27307)

#### Tagged
@lampkicking/ios-dev