### PR TITLE
[YM-28202] Android: introduce faceCenter parameter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${project.ext.kotlinVersion}"
-    implementation 'com.yoti.mobile.android:face-capture-bundled:3.0.0'
+    implementation 'com.yoti.mobile.android:face-capture-bundled:4.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'

--- a/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureView.java
+++ b/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureView.java
@@ -1,10 +1,10 @@
 package com.yoti.reactnative.facecapture;
 
+import android.graphics.PointF;
 import android.util.Base64;
 import android.view.Choreographer;
 import android.view.View;
 import android.widget.LinearLayout;
-import android.graphics.Rect;
 
 import androidx.lifecycle.LifecycleOwner;
 
@@ -34,7 +34,7 @@ public class YotiFaceCaptureView extends LinearLayout {
   private boolean mRequireEyesOpen;
   private boolean mRequireBrightEnvironment = true;
   private int mRequiredStableFrames;
-  private ReadableArray mScanningArea;
+  private ReadableArray mFaceCenter;
   private final CameraStateListener mCameraStateListener = new CameraStateListener() {
     @Override
     public void onCameraState(@NotNull CameraState cameraState) {
@@ -121,8 +121,8 @@ public class YotiFaceCaptureView extends LinearLayout {
     super.requestLayout();
   }
 
-  public void setScanningArea(ReadableArray scanningArea) throws Exception {
-    mScanningArea = scanningArea;
+  public void setFaceCenter(ReadableArray faceCenter) throws Exception {
+    mFaceCenter = faceCenter;
   }
 
   public void setImageQuality(String imageQuality) throws Exception {
@@ -166,15 +166,10 @@ public class YotiFaceCaptureView extends LinearLayout {
   }
 
   public void startAnalyzing() {
-    Rect scanningArea = new Rect(
-      mScanningArea.getInt(0),
-      mScanningArea.getInt(1),
-      mScanningArea.getInt(0) + mScanningArea.getInt(2),
-      mScanningArea.getInt(1) + mScanningArea.getInt(3)
-    );
+    PointF faceCenter = new PointF((float) mFaceCenter.getDouble(0), (float) mFaceCenter.getDouble(1));
 
     FaceCaptureConfiguration configuration = new FaceCaptureConfiguration(
-      scanningArea,
+      faceCenter,
       mImageQuality,
       mRequireValidAngle,
       mRequireEyesOpen,

--- a/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureViewManager.java
+++ b/android/src/main/java/com/yoti/reactnative/facecapture/YotiFaceCaptureViewManager.java
@@ -40,10 +40,10 @@ public class YotiFaceCaptureViewManager extends SimpleViewManager<YotiFaceCaptur
       .build();
   }
 
-  @ReactProp(name = "scanningArea")
-  public void setScanningArea(YotiFaceCaptureView view, ReadableArray scanningArea) throws Exception {
+  @ReactProp(name = "faceCenter")
+  public void setFaceCenter(YotiFaceCaptureView view, ReadableArray faceCenter) throws Exception {
     try {
-      view.setScanningArea(scanningArea);
+      view.setFaceCenter(faceCenter);
     } catch (Exception e) {
       throw e;
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -3,7 +3,6 @@ import AutoHeightImage from 'react-native-auto-height-image';
 import { check, PERMISSIONS, request, RESULTS } from 'react-native-permissions';
 import {
   Platform,
-  PixelRatio,
   StyleSheet,
   View,
   TouchableOpacity,
@@ -15,21 +14,12 @@ import YotiFaceCapture, {
 } from '@getyoti/react-native-yoti-face-capture';
 
 export default function App() {
-  const windowHeight = useWindowDimensions().height;
-  const windowWidth = useWindowDimensions().width;
   const YotiFaceCaptureRef = React.useRef(null);
 
   const [base64, setBase64] = React.useState(false);
   const [cameraIsRunning, setCameraIsRunning] = React.useState(false);
   const [isAnalyzing, setIsAnalyzing] = React.useState(false);
   const [latestState, setLatestState] = React.useState('');
-  const [nativeWindowHeight, setNativeWindowHeight] = React.useState(0);
-  const [nativeWindowWidth, setNativeWindowWidth] = React.useState(0);
-
-  React.useEffect(() => {
-    setNativeWindowHeight(PixelRatio.getPixelSizeForLayoutSize(windowHeight));
-    setNativeWindowWidth(PixelRatio.getPixelSizeForLayoutSize(windowWidth));
-  }, [windowHeight, windowWidth]);
 
 
   React.useEffect(() => {
@@ -74,7 +64,7 @@ export default function App() {
         requiredStableFrames={1}
         requireValidAngle={false}
         requireBrightEnvironment
-        scanningArea={[0, 0, nativeWindowWidth, nativeWindowHeight]}
+        faceCenter={[0.5, 0.5]}
         onFaceCaptureAnalyzedImage={(result) => {
           const { croppedImage } = result;
           const uri = `data:image/jpg;base64,${croppedImage}`;

--- a/src/RNYotiCapture.android.tsx
+++ b/src/RNYotiCapture.android.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   findNodeHandle,
-  PixelRatio,
   requireNativeComponent,
   NativeModules,
 } from 'react-native';
@@ -80,7 +79,7 @@ interface NativeFaceCaptureViewAndroid {
   requiredStableFrames: number;
   requireBrightEnvironment: Boolean;
   imageQuality: IMAGE_QUALITY;
-  scanningArea: Array<number>;
+  faceCenter: Array<number>;
   onCameraStateChange: (
     faceCaptureState: NativeFaceCaptureState | NativeFaceCaptureStateFailure
   ) => void;
@@ -215,11 +214,9 @@ export default class RNYotiCapture extends React.Component<ComponentProps> {
       requireValidAngle = false,
       requiredStableFrames = 3,
       imageQuality = IMAGE_QUALITY_MEDIUM,
-      scanningArea = [
-        0,
-        0,
-        PixelRatio.getPixelSizeForLayoutSize(720),
-        PixelRatio.getPixelSizeForLayoutSize(1280),
+      faceCenter = [
+        0.5,
+        0.5
       ],
     } = this.props;
 
@@ -231,7 +228,7 @@ export default class RNYotiCapture extends React.Component<ComponentProps> {
         requiredStableFrames={requiredStableFrames}
         requireBrightEnvironment={requireBrightEnvironment}
         imageQuality={imageQuality}
-        scanningArea={scanningArea}
+        faceCenter={faceCenter}
         ref={this._setReference}
         onCameraStateChange={this.onCameraStateChange.bind(this)}
         onFaceCaptureResult={this.onFaceCaptureResult.bind(this)}

--- a/src/RNYotiCapture.ios.tsx
+++ b/src/RNYotiCapture.ios.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   findNodeHandle,
-  PixelRatio,
   requireNativeComponent,
   UIManager,
 } from 'react-native';
@@ -46,7 +45,7 @@ interface NativeFaceCaptureViewIOS {
   requireValidAngle: boolean;
   requiredStableFrames: number;
   requireBrightEnvironment: boolean;
-  scanningArea: Array<number>;
+  faceCenter: Array<number>;
   onFaceCaptureAnalyzedImage: (
     faceCaptureResult: NativeFaceCaptureResult
   ) => void;
@@ -121,11 +120,9 @@ export default class RNYotiCapture extends React.Component<ComponentProps> {
       requiredStableFrames = 3,
       requireBrightEnvironment = true,
       imageQuality = IMAGE_QUALITY_MEDIUM,
-      scanningArea = [
-        0,
-        0,
-        PixelRatio.getPixelSizeForLayoutSize(720),
-        PixelRatio.getPixelSizeForLayoutSize(1280),
+      faceCenter = [
+        0.5,
+        0.5
       ],
     } = this.props;
     return (
@@ -136,7 +133,7 @@ export default class RNYotiCapture extends React.Component<ComponentProps> {
         requiredStableFrames={requiredStableFrames}
         requireBrightEnvironment={requireBrightEnvironment}
         imageQuality={imageQuality}
-        scanningArea={scanningArea}
+        faceCenter={faceCenter}
         onFaceCaptureAnalyzedImage={({
           nativeEvent: faceCaptureResult,
         }: NativeFaceCaptureResult) =>

--- a/src/RNYotiCaptureTypes.tsx
+++ b/src/RNYotiCaptureTypes.tsx
@@ -95,7 +95,7 @@ export type ComponentProps = {
   requiredStableFrames?: number;
   requireBrightEnvironment?: boolean;
   imageQuality?: IMAGE_QUALITY;
-  scanningArea?: Array<number>;
+  faceCenter?: Array<number>;
   onFaceCaptureAnalyzedImage: (faceCaptureResult: FaceCaptureResult) => void;
   onFaceCaptureImageAnalysisFailed: (
     faceCaptureAnalysisFailure: FaceCaptureAnalysisFailure


### PR DESCRIPTION
## Purpose
Breaking change: Introduce faceCenter parameter and remove scanningArea one. 

## External References (e.g. Jira / Zeplin / Confluence)
[YM-28202](https://lampkicking.atlassian.net/browse/YM-28202)

## Approach
- Point to native Android FCM 4.0.0, which introduces the faceCenter parameter.
- Update config parameters and sample app to set the image center.

## Scope of changes
Configuration parameters & Android project configuration.

## Checklist
- [ ] Execute Android demo app and check that imageCenter is well calculated: 
Check you're able to capture your face if you center your face in the frame, if not, "faceNotCentered" error is shown.

