### PR TITLE
[YM-29951] React Native Android App crashes on launch

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -187,8 +187,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.facebook.react:react-native:0.63.5"  // From package.json
 
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
@@ -222,3 +221,4 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.63.4",
+    "react-native": "0.63.5",
     "react-native-auto-height-image": "^3.2.4",
     "react-native-permissions": "^3.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pod-install": "^0.1.0",
     "prettier": "^2.0.5",
     "react": "16.13.1",
-    "react-native": "0.63.4",
+    "react-native": "0.63.5",
     "react-native-builder-bob": "^0.18.0",
     "release-it": "^14.2.2",
     "typescript": "^4.1.3"


### PR DESCRIPTION
## Purpose
### React Native Android App crashes on launch
Historically, the React Native template provided build.gradle files that contain a dependency on the React Native Android library as follows: implementation("com.facebook.react:react-native:+").

Specifically, the + part of this dependency declaration is causing Gradle to pick the highest version among all the declared repositories (often referred as Gradle Dynamic versions). Till React Native version 0.70, we were shipping a Maven Repository inside the NPM package (inside the ./android folder). Starting from 0.71, we moved such folder and uploaded it to Maven Central.
[Ref](https://github.com/facebook/react-native/issues/35210)

## External References (e.g. Jira / Zeplin / Confluence)
- [Jira](https://lampkicking.atlassian.net/browse/YM-29951)

## Approach
- Update react native version

## Scope of changes
- React Native

## Checklist
- Execute Android demo app [here](https://github.com/getyoti/react-native-yoti-face-capture/tree/main/example)
- [ ] Check that the application builds successfully, launches and is able to capture your face by placing your face in the middle of the screen.