### PR TITLE
[YM-29951] Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # ChangeLog
+## Version 3.0.1
+
+Contains a couple of bug fixes on the Android side of the SDK:
+- Fixes issue with `react-native` `< 0.63` resulting in app a crash on launch.
+
 ## Version 3.0.0
 BREAKING CHANGE: New configuration requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getyoti/react-native-yoti-face-capture",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "An easy to use face detection component for React Native from Yoti.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Purpose

Contains a couple of bug fixes on the Android side of the SDK:
- Upgrade RN to 0.63.5 to fix Android sample app crash. More info [here](https://github.com/facebook/react-native/issues/35210)